### PR TITLE
Fix crash when conversation not synced in getLastMessages/getAllMessages

### DIFF
--- a/android/src/main/java/com/at/twilio_conversation_sdk/conversation/ConversationHandler.java
+++ b/android/src/main/java/com/at/twilio_conversation_sdk/conversation/ConversationHandler.java
@@ -552,6 +552,7 @@ public class ConversationHandler {
                 AtomicInteger pendingCallbacks = new AtomicInteger(1); // Track pending callbacks
                 Map<String, Object> conversationMap = new HashMap<>();
 
+                try {
                 conversation.getLastMessages(1, new CallbackListener<List<Message>>() {
                     @Override
                     public void onSuccess(List<Message> messages) {
@@ -609,7 +610,10 @@ public class ConversationHandler {
                         list.add(messagesMap);
                         result.success(list);
                     }
-                });
+                }); } catch (IllegalStateException e) {
+                    System.out.println("getLastMessages: conversation not synced: " + e.getMessage());
+                    result.success(list);
+                }
             }
 
             @Override
@@ -658,6 +662,7 @@ public class ConversationHandler {
         conversationClient.getConversation(conversationId, new CallbackListener<Conversation>() {
             @Override
             public void onSuccess(Conversation conversation) {
+                try {
                 conversation.getLastMessages((messageCount != null) ? messageCount : 1000, new CallbackListener<List<Message>>() {
                     @Override
                     public void onSuccess(List<Message> messagesList) {
@@ -745,7 +750,10 @@ public class ConversationHandler {
                         result.success(list);
                         //result.error("MESSAGE_RETRIEVAL_ERROR", errorInfo.getMessage(), null);
                     }
-                });
+                }); } catch (IllegalStateException e) {
+                    System.out.println("getAllMessages: conversation not synced: " + e.getMessage());
+                    result.success(list);
+                }
             }
 
             @Override

--- a/android/src/main/java/com/at/twilio_conversation_sdk/conversation/ConversationHandler.java
+++ b/android/src/main/java/com/at/twilio_conversation_sdk/conversation/ConversationHandler.java
@@ -149,7 +149,8 @@ public class ConversationHandler {
 
             @Override
             public void onError(ErrorInfo errorInfo) {
-                CallbackListener.super.onError(errorInfo);
+                System.out.println("addParticipant: failed to get conversation: " + errorInfo.getMessage());
+                result.success(errorInfo.getMessage());
             }
         });
     }

--- a/ios/Classes/Conversation/ConversationHandler.swift
+++ b/ios/Classes/Conversation/ConversationHandler.swift
@@ -275,6 +275,8 @@ class ConversationsHandler: NSObject, TwilioConversationsClientDelegate {
     
     func createConversation(uniqueConversationName:String,_ completion: @escaping (Bool, TCHConversation?,String) -> Void) {
         guard let client = client else {
+            print("createConversation: client is nil")
+            completion(false, nil, "client not available")
             return
         }
         // Create the conversation if it hasn't been created yet
@@ -293,12 +295,15 @@ class ConversationsHandler: NSObject, TwilioConversationsClientDelegate {
     
     func getConversations(_ completion: @escaping([TCHConversation]) -> Void) {
         guard let client = client else {
+            print("getConversations: client is nil")
+            completion([])
             return
         }
         guard client.synchronizationStatus == .completed else {
+            print("getConversations: client not synced, status=\(client.synchronizationStatus.rawValue)")
+            completion(client.myConversations() ?? [])
             return
         }
-        
         completion(client.myConversations() ?? [])
     }
     
@@ -310,7 +315,12 @@ class ConversationsHandler: NSObject, TwilioConversationsClientDelegate {
     
     func addParticipants(conversationId:String,participantName:String,_ completion: @escaping(TCHResult?) -> Void) {
         self.getConversationFromId(conversationId: conversationId) { conversation in
-            conversation?.addParticipant(byIdentity: participantName, attributes: nil,completion: { status in
+            guard let conversation = conversation else {
+                print("addParticipants: failed to get conversation: \(conversationId)")
+                completion(nil)
+                return
+            }
+            conversation.addParticipant(byIdentity: participantName, attributes: nil,completion: { status in
                 completion(status)
             })
         }
@@ -345,32 +355,40 @@ class ConversationsHandler: NSObject, TwilioConversationsClientDelegate {
     
     func getConversationFromId(conversationId:String,_ completion: @escaping(TCHConversation?) -> Void){
         guard let client = client else {
+            completion(nil)
+            return
+        }
+        // Check local cache first to avoid async lookup that may never call back
+        // for newly created or not-yet-synced conversations.
+        if let local = client.myConversations()?.first(where: {
+            $0.sid == conversationId || $0.uniqueName == conversationId
+        }) {
+            completion(local)
             return
         }
         guard client.synchronizationStatus == .completed else {
+            completion(nil)
             return
         }
         client.conversation(withSidOrUniqueName: conversationId) { (result, conversation) in
-            if let conversationFromSid = conversation {
-                print("message readed")
-                completion(conversationFromSid)
-            }
+            completion(conversation)
         }
     }
     
     func loadPreviousMessages(_ conversation: TCHConversation,_ messageCount: UInt?,_ completion: @escaping([[String: Any]]?) -> Void) {
         print("synchronizationStatus->\(client?.synchronizationStatus == .completed)")
         guard client?.synchronizationStatus == .completed else {
+            completion([])
             return
         }
-        var listOfMessagess: [[String: Any]] = []
         conversation.getLastMessages(withCount: messageCount ?? 1000) { (result, messages) in
-            if let messagesList = messages {
-                self.processMessagesSequentially(messagesList: messagesList) { result in
-                    completion(result) // Return the final processed list
-                }
+            guard let messagesList = messages, !messagesList.isEmpty else {
+                completion([])
+                return
             }
-            
+            self.processMessagesSequentially(messagesList: messagesList) { result in
+                completion(result)
+            }
         }
     }
     
@@ -433,14 +451,16 @@ class ConversationsHandler: NSObject, TwilioConversationsClientDelegate {
     func getLastMessage(_ conversation: TCHConversation,_ messageCount: UInt?,_ completion: @escaping([[String: Any]]?) -> Void) {
         print("synchronizationStatus->\(client?.synchronizationStatus == .completed)")
         guard client?.synchronizationStatus == .completed else {
+            completion([])
             return
         }
-        var listOfMessagess: [[String: Any]] = []
         conversation.getLastMessages(withCount: messageCount ?? 1) { (result, messages) in
-            if let messagesList = messages {
-                self.processMessagesSequentiallyForParticipants(conversation,messagesList: messagesList) { result in
-                    completion(result) // Return the final processed list
-                }
+            guard let messagesList = messages, !messagesList.isEmpty else {
+                completion([])
+                return
+            }
+            self.processMessagesSequentiallyForParticipants(conversation, messagesList: messagesList) { result in
+                completion(result)
             }
         }
     }

--- a/ios/Classes/TwilioConversationSdkPlugin.swift
+++ b/ios/Classes/TwilioConversationSdkPlugin.swift
@@ -109,7 +109,7 @@ public class TwilioConversationSdkPlugin: NSObject, FlutterPlugin,FlutterStreamH
             self.conversationsHandler.createConversation (uniqueConversationName: arguments?["conversationName"] as! String){ (success, conversation,status)  in
                 if success, let conversation = conversation {
                     self.conversationsHandler.joinConversation(conversation) { joinConversationStatus in}
-                    result(Strings.createConversationSuccess)
+                    result(conversation.sid ?? Strings.createConversationSuccess)
                 }else {
                     if (status == Strings.conversationExists) {
                         result(Strings.conversationExists)
@@ -241,6 +241,8 @@ public class TwilioConversationSdkPlugin: NSObject, FlutterPlugin,FlutterStreamH
                     }else {
                         result(addParticipantStatus.resultText)
                     }
+                } else {
+                    result("addParticipant: conversation not available")
                 }
             }
             break
@@ -261,6 +263,8 @@ public class TwilioConversationSdkPlugin: NSObject, FlutterPlugin,FlutterStreamH
                     self.conversationsHandler.joinConversation(conversationFromId) { tchConversationStatus in
                         result(tchConversationStatus)
                     }
+                } else {
+                    result(nil)
                 }
             }
         case Methods.getMessages:
@@ -268,9 +272,10 @@ public class TwilioConversationSdkPlugin: NSObject, FlutterPlugin,FlutterStreamH
                 self.conversationsHandler.conversationId = arguments?["conversationId"] as? String
                 if let conversationFromId = conversation {
                     self.conversationsHandler.loadPreviousMessages(conversationFromId,arguments?["messageCount"] as? UInt) { listOfMessages in
-                        //                      print("listOfMessagess->\(String(describing: listOfMessages))")
                         result(listOfMessages)
                     }
+                } else {
+                    result([])
                 }
             }
             break
@@ -278,9 +283,10 @@ public class TwilioConversationSdkPlugin: NSObject, FlutterPlugin,FlutterStreamH
             self.conversationsHandler.getConversationFromId(conversationId: arguments?["conversationId"] as! String) { conversation in
                 if let conversationFromId = conversation {
                     self.conversationsHandler.getLastMessage(conversationFromId,arguments?["messageCount"] as? UInt) { listOfMessages in
-                        //                      print("listOfMessagess->\(String(describing: listOfMessages))")
                         result(listOfMessages)
                     }
+                } else {
+                    result([])
                 }
             }
             break


### PR DESCRIPTION
  ## Problem
  Twilio SDK throws `IllegalStateException: Messages are not available at
  the moment. Synchronize the conversation first.` synchronously inside a
  listener callback when a conversation hasn't been fully synced yet.

  Because Twilio's `RethrowingForwarder` re-throws any exception from
  listener callbacks, this becomes a fatal crash on Android.

  ## Fix
  Wrap `conversation.getLastMessages(...)` calls in both `getLastMessages()`
  and `getAllMessages()` with `try/catch (IllegalStateException)`. When caught,

  the method returns an empty list gracefully instead of crashing.